### PR TITLE
Fix quick wins and medium effort issues (#2, #3, #4, #5, #7, #10, #12)

### DIFF
--- a/src/main/connectors/bigquery.ts
+++ b/src/main/connectors/bigquery.ts
@@ -123,15 +123,8 @@ export class BigQueryConnector implements DatabaseConnector {
 
     const columns = Object.keys(rows[0]);
 
-    const jsonSafeRows = JSON.parse(JSON.stringify(rows, (_key, value) => {
-      if (typeof value === 'bigint') {
-        return value.toString();
-      }
-      return value;
-    }));
-
-    const formattedRows = jsonSafeRows.map((row: any) =>
-      columns.map((col) => row[col])
+    const formattedRows = rows.map((row: any) =>
+      columns.map((col) => this.serializeValue(row[col]))
     );
 
     return {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -259,7 +259,14 @@ handleIPC('file-read', async (_event, filePath: string) => {
 
 handleIPC('file-write', async (_event, filePath: string, content: string) => {
   validateFilePath(filePath);
-  await fileSystemService.writeFile(filePath, content);
+  // Suppress file watcher notifications during our own writes
+  fileWatcherService.suppressPath(filePath);
+  try {
+    await fileSystemService.writeFile(filePath, content);
+  } finally {
+    // Delay unsuppression to allow file system events to settle
+    setTimeout(() => fileWatcherService.unsuppressPath(filePath), 500);
+  }
 });
 
 handleIPC('file-create', async (_event, filePath: string, content?: string) => {
@@ -275,7 +282,19 @@ handleIPC('file-delete', async (_event, filePath: string) => {
 handleIPC('file-rename', async (_event, oldPath: string, newPath: string) => {
   validateFilePath(oldPath);
   validateFilePath(newPath);
-  await fileSystemService.renameFile(oldPath, newPath);
+  // Suppress file watcher for the old path to prevent "deleted" notification
+  fileWatcherService.suppressPath(oldPath);
+  try {
+    await fileSystemService.renameFile(oldPath, newPath);
+    // Update the watcher to track the new path
+    fileWatcherService.updateWatchedPath(oldPath, newPath);
+    // Notify renderer of the rename so it can update tab/file references
+    if (mainWindow) {
+      mainWindow.webContents.send('file-renamed', oldPath, newPath);
+    }
+  } finally {
+    setTimeout(() => fileWatcherService.unsuppressPath(oldPath), 500);
+  }
 });
 
 handleIPC('folder-create', async (_event, folderPath: string) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -261,11 +261,17 @@ handleIPC('file-write', async (_event, filePath: string, content: string) => {
   validateFilePath(filePath);
   // Suppress file watcher notifications during our own writes
   fileWatcherService.suppressPath(filePath);
+  console.log(`[FileWatcher] Suppressed: ${filePath}`);
   try {
     await fileSystemService.writeFile(filePath, content);
+    console.log(`[FileWatcher] Write complete: ${filePath}`);
   } finally {
     // Delay unsuppression to allow file system events to settle
-    setTimeout(() => fileWatcherService.unsuppressPath(filePath), 500);
+    // chokidar has 300ms stabilityThreshold, plus write time, so use 1500ms to be safe
+    setTimeout(() => {
+      fileWatcherService.unsuppressPath(filePath);
+      console.log(`[FileWatcher] Unsuppressed: ${filePath}`);
+    }, 1500);
   }
 });
 

--- a/src/main/services/FileWatcherService.ts
+++ b/src/main/services/FileWatcherService.ts
@@ -65,7 +65,9 @@ export class FileWatcherService {
     });
 
     watcher.on('change', () => {
-      if (this.window && !this.isPathSuppressed(filePath)) {
+      const isSuppressed = this.isPathSuppressed(filePath);
+      console.log(`[FileWatcher] Change detected: ${filePath}, suppressed: ${isSuppressed}`);
+      if (this.window && !isSuppressed) {
         this.window.webContents.send('file-changed', filePath);
       }
     });

--- a/src/main/services/FileWatcherService.ts
+++ b/src/main/services/FileWatcherService.ts
@@ -8,9 +8,46 @@ export class FileWatcherService {
   private watchers: Map<string, FSWatcher> = new Map();
   private folderWatchers: Map<string, FSWatcher> = new Map();
   private window: BrowserWindow | null = null;
+  private suppressedPaths: Set<string> = new Set();
 
   setWindow(window: BrowserWindow): void {
     this.window = window;
+  }
+
+  /**
+   * Suppress file watcher notifications for a path.
+   * Use this before making changes to a file from within the app.
+   */
+  suppressPath(filePath: string): void {
+    this.suppressedPaths.add(filePath);
+  }
+
+  /**
+   * Re-enable notifications for a path after suppression.
+   */
+  unsuppressPath(filePath: string): void {
+    this.suppressedPaths.delete(filePath);
+  }
+
+  /**
+   * Check if a path is currently suppressed.
+   */
+  isPathSuppressed(filePath: string): boolean {
+    return this.suppressedPaths.has(filePath);
+  }
+
+  /**
+   * Update a watched file path (used when renaming).
+   * Transfers the watcher from oldPath to newPath without triggering events.
+   */
+  updateWatchedPath(oldPath: string, newPath: string): void {
+    const watcher = this.watchers.get(oldPath);
+    if (watcher) {
+      watcher.close();
+      this.watchers.delete(oldPath);
+      // Start watching the new path
+      this.watchFile(newPath);
+    }
   }
 
   watchFile(filePath: string): void {
@@ -28,13 +65,13 @@ export class FileWatcherService {
     });
 
     watcher.on('change', () => {
-      if (this.window) {
+      if (this.window && !this.isPathSuppressed(filePath)) {
         this.window.webContents.send('file-changed', filePath);
       }
     });
 
     watcher.on('unlink', () => {
-      if (this.window) {
+      if (this.window && !this.isPathSuppressed(filePath)) {
         this.window.webContents.send('file-deleted', filePath);
       }
       this.unwatchFile(filePath);

--- a/src/renderer/App-new.css
+++ b/src/renderer/App-new.css
@@ -384,6 +384,8 @@
   min-height: 0;
   overflow: hidden;
   background-color: var(--color-bg);
+  display: flex;
+  flex-direction: column;
 }
 
 .results-table {

--- a/src/renderer/App-new.css
+++ b/src/renderer/App-new.css
@@ -286,6 +286,42 @@
   opacity: 0.5;
 }
 
+/* Resize handle between editor and results */
+.resize-handle-horizontal {
+  height: 6px;
+  width: 100%;
+  cursor: row-resize;
+  background: transparent;
+  flex-shrink: 0;
+  z-index: 50;
+  position: relative;
+}
+
+.resize-handle-horizontal::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--color-border);
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.resize-handle-horizontal:hover::before,
+.resize-handle-horizontal.active::before {
+  background: var(--color-accent);
+  opacity: 1;
+}
+
+.resize-handle-horizontal:hover,
+.resize-handle-horizontal.active {
+  background: var(--color-accent-light);
+}
+
 .main-panel {
   flex: 1;
   display: flex;
@@ -294,7 +330,6 @@
 }
 
 .editor-container {
-  flex: 1;
   min-height: 0;
   border-bottom: 1px solid var(--color-border);
   background-color: var(--color-surface);
@@ -346,7 +381,6 @@
 }
 
 .results-container {
-  flex: 1;
   min-height: 0;
   overflow: hidden;
   background-color: var(--color-bg);

--- a/src/renderer/App-new.tsx
+++ b/src/renderer/App-new.tsx
@@ -114,6 +114,8 @@ function App() {
   const [schemaTables, setSchemaTables] = useState<import('../shared/types').Table[]>([]);
   const schemaTablesRef = useRef<import('../shared/types').Table[]>([]);
   const recentTablesRef = useRef<string[]>([]);
+  const executeRef = useRef<() => void>(() => {});
+  const executeAllRef = useRef<() => void>(() => {});
 
   const activeTab = tabs.find((t) => t.id === activeTabId) || tabs[0];
 
@@ -353,6 +355,25 @@ function App() {
       setIsExecuting(false);
     }
   };
+
+  // Keep refs updated for Monaco editor actions (avoids stale closure issue)
+  useEffect(() => {
+    executeRef.current = () => {
+      if (isConnected && !isExecuting) {
+        handleExecute();
+      }
+    };
+    executeAllRef.current = () => {
+      if (isConnected && !isExecuting) {
+        const originalMode = executionMode;
+        setExecutionMode('all');
+        setTimeout(() => {
+          handleExecute();
+          setExecutionMode(originalMode);
+        }, 0);
+      }
+    };
+  });
 
   // Keyboard shortcuts - must be after handleExecute is defined
   useEffect(() => {
@@ -992,17 +1013,14 @@ function App() {
             editorRef.current = editor;
 
             // Add Cmd/Ctrl+Enter keybinding to execute query
+            // Uses ref to avoid stale closure issue
             editor.addAction({
               id: 'execute-query',
               label: 'Execute Query',
               keybindings: [
                 monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
               ],
-              run: () => {
-                if (isConnected && !isExecuting) {
-                  handleExecute();
-                }
-              },
+              run: () => executeRef.current(),
             });
 
             // Add Cmd/Ctrl+Shift+Enter keybinding to execute all queries
@@ -1012,17 +1030,7 @@ function App() {
               keybindings: [
                 monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter,
               ],
-              run: () => {
-                if (isConnected && !isExecuting) {
-                  // Temporarily switch to 'all' mode and execute
-                  const originalMode = executionMode;
-                  setExecutionMode('all');
-                  setTimeout(() => {
-                    handleExecute();
-                    setExecutionMode(originalMode);
-                  }, 0);
-                }
-              },
+              run: () => executeAllRef.current(),
             });
           }}
           options={{

--- a/src/renderer/App-new.tsx
+++ b/src/renderer/App-new.tsx
@@ -26,6 +26,7 @@ import {
   extractTablesFromQuery,
   getMultiTableColumnCompletions,
   isInSelectClause,
+  isInComment,
 } from './utils/sqlCompletions';
 import './design-system.css';
 import './App-new.css';
@@ -921,6 +922,14 @@ function App() {
             monaco.languages.registerCompletionItemProvider('sql', {
               triggerCharacters: ['.', ' '],
               provideCompletionItems: (model: Monaco.editor.ITextModel, position: Monaco.Position) => {
+                const fullText = model.getValue();
+                const cursorOffset = model.getOffsetAt(position);
+
+                // Don't provide completions inside comments
+                if (isInComment(fullText, cursorOffset)) {
+                  return { suggestions: [] };
+                }
+
                 const word = model.getWordUntilPosition(position);
                 const range = {
                   startLineNumber: position.lineNumber,

--- a/src/renderer/App-new.tsx
+++ b/src/renderer/App-new.tsx
@@ -813,13 +813,27 @@ function App() {
       }
     };
 
+    const handleFileRenamed = (_event: any, oldPath: string, newPath: string) => {
+      // Update any tab that references the old path
+      setTabs(prevTabs => prevTabs.map(tab => {
+        if (tab.filePath === oldPath) {
+          // Extract new filename for title
+          const newName = newPath.split('/').pop() || newPath;
+          return { ...tab, filePath: newPath, title: newName };
+        }
+        return tab;
+      }));
+    };
+
     if (window.electron.ipcRenderer) {
       window.electron.ipcRenderer.on('file-changed', handleFileChanged);
       window.electron.ipcRenderer.on('file-deleted', handleFileDeleted);
+      window.electron.ipcRenderer.on('file-renamed', handleFileRenamed);
 
       return () => {
         window.electron.ipcRenderer?.removeListener('file-changed', handleFileChanged);
         window.electron.ipcRenderer?.removeListener('file-deleted', handleFileDeleted);
+        window.electron.ipcRenderer?.removeListener('file-renamed', handleFileRenamed);
       };
     }
   }, []); // Empty deps - only run on mount/unmount

--- a/src/renderer/App-new.tsx
+++ b/src/renderer/App-new.tsx
@@ -246,8 +246,10 @@ function App() {
     }
   };
 
-  const handleExecute = async () => {
+  const handleExecute = async (modeOverride?: ExecutionMode) => {
     if (!isConnected || !activeTab || !editorRef.current) return;
+
+    const mode = modeOverride ?? executionMode;
 
     setError(null);
     setIsExecuting(true);
@@ -275,7 +277,7 @@ function App() {
             endLine: selection.startLineNumber + q.endLine - 1,
           }));
         }
-      } else if (executionMode === 'current' && position) {
+      } else if (mode === 'current' && position) {
         // Run query at cursor position
         const query = getQueryAtPosition(activeTab.sql, position.lineNumber, position.column);
         if (query) {
@@ -369,12 +371,7 @@ function App() {
     };
     executeAllRef.current = () => {
       if (isConnected && !isExecuting) {
-        const originalMode = executionMode;
-        setExecutionMode('all');
-        setTimeout(() => {
-          handleExecute();
-          setExecutionMode(originalMode);
-        }, 0);
+        handleExecute('all');
       }
     };
   });
@@ -387,13 +384,8 @@ function App() {
         if (!isConnected || isExecuting) return;
 
         if (e.shiftKey) {
-          // Cmd+Shift+Enter: Execute All - temporarily set mode to 'all'
-          const originalMode = executionMode;
-          setExecutionMode('all');
-          setTimeout(() => {
-            handleExecute();
-            setExecutionMode(originalMode);
-          }, 0);
+          // Cmd+Shift+Enter: Execute All
+          handleExecute('all');
         } else {
           // Cmd+Enter: Execute based on current mode
           handleExecute();

--- a/src/renderer/App-new.tsx
+++ b/src/renderer/App-new.tsx
@@ -106,10 +106,13 @@ function App() {
   const [isResizingFile, setIsResizingFile] = useState(false);
   const [isResizingStacked, setIsResizingStacked] = useState(false);
   const [isResizingBrowsers, setIsResizingBrowsers] = useState(false);
+  const [isResizingEditorResults, setIsResizingEditorResults] = useState(false);
+  const [editorResultsRatio, setEditorResultsRatio] = useState(0.5);
   const resizeStartX = useRef(0);
   const resizeStartY = useRef(0);
   const resizeStartWidth = useRef(0);
   const resizeStartRatio = useRef(0.5);
+  const mainPanelRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<typeof Monaco | null>(null);
   const [schemaTables, setSchemaTables] = useState<import('../shared/types').Table[]>([]);
@@ -657,6 +660,13 @@ function App() {
     resizeStartRatio.current = browserSplitRatio;
   };
 
+  const handleEditorResultsResizeStart = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsResizingEditorResults(true);
+    resizeStartY.current = e.clientY;
+    resizeStartRatio.current = editorResultsRatio;
+  };
+
   useEffect(() => {
     if (!isResizingSchema) return;
 
@@ -754,6 +764,33 @@ function App() {
       document.removeEventListener('mouseup', handleMouseUp);
     };
   }, [isResizingBrowsers]);
+
+  useEffect(() => {
+    if (!isResizingEditorResults) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const container = mainPanelRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const deltaY = e.clientY - resizeStartY.current;
+      const containerHeight = rect.height;
+      const deltaRatio = deltaY / containerHeight;
+      const newRatio = Math.max(0.15, Math.min(0.85, resizeStartRatio.current + deltaRatio));
+      setEditorResultsRatio(newRatio);
+    };
+
+    const handleMouseUp = () => {
+      setIsResizingEditorResults(false);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isResizingEditorResults]);
 
   // Warn before closing window with unsaved changes
   useEffect(() => {
@@ -899,8 +936,8 @@ function App() {
   );
 
   const renderMainPanel = () => (
-    <div className="main-panel">
-      <div className="editor-container">
+    <div className="main-panel" ref={mainPanelRef}>
+      <div className="editor-container" style={{ flex: `0 0 ${editorResultsRatio * 100}%` }}>
         {activeTab.filePath && changedFiles.has(activeTab.filePath) && (
           <div className="file-changed-banner">
             <span>This file was changed externally.</span>
@@ -1072,7 +1109,12 @@ function App() {
         />
       </div>
 
-      <div className="results-container">
+      <div
+        className={`resize-handle-horizontal ${isResizingEditorResults ? 'active' : ''}`}
+        onMouseDown={handleEditorResultsResizeStart}
+      />
+
+      <div className="results-container" style={{ flex: `0 0 ${(1 - editorResultsRatio) * 100}%` }}>
         {error && <div className="error">{error}</div>}
 
         {activeTab.results && (

--- a/src/renderer/components/ResultsTable.css
+++ b/src/renderer/components/ResultsTable.css
@@ -485,3 +485,37 @@
   border-color: var(--color-warning);
   color: var(--color-warning);
 }
+
+/* Context menu */
+.results-context-menu {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: 1000;
+  min-width: 120px;
+  padding: var(--space-1) 0;
+}
+
+.context-menu-item {
+  display: block;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  background: none;
+  text-align: left;
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.context-menu-item:hover {
+  background: var(--color-accent-light);
+}
+
+.context-menu-item:active {
+  background: var(--color-accent);
+  color: white;
+}

--- a/src/renderer/components/ResultsTable.css
+++ b/src/renderer/components/ResultsTable.css
@@ -4,7 +4,8 @@
 .results-table-container {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   background: var(--color-surface);
 }
 

--- a/src/renderer/components/ResultsTable.tsx
+++ b/src/renderer/components/ResultsTable.tsx
@@ -203,20 +203,36 @@ export function ResultsTable({ results, filters, onFiltersChange, onExportCSV, o
     return columnFilters.find((f) => f.columnIndex === columnIndex);
   };
 
+  // Format a value for clipboard/display as a string
+  const formatValueForCopy = useCallback((value: unknown): string => {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+    if (typeof value === 'object') {
+      if ('value' in value && typeof (value as any).value !== 'undefined') {
+        return formatValueForCopy((value as any).value);
+      }
+      return JSON.stringify(value);
+    }
+    return String(value);
+  }, []);
+
   // Copy cell value to clipboard
   const copyCellValue = useCallback((row: number, col: number) => {
     const value = paginatedRows[row]?.[col];
-    const text = value === null || value === undefined ? '' : String(value);
-    navigator.clipboard.writeText(text);
-  }, [paginatedRows]);
+    navigator.clipboard.writeText(formatValueForCopy(value));
+  }, [paginatedRows, formatValueForCopy]);
 
   // Copy entire row to clipboard
   const copyRowValue = useCallback((row: number) => {
     const rowData = paginatedRows[row];
     if (!rowData) return;
-    const text = rowData.map((cell) => (cell === null || cell === undefined ? '' : String(cell))).join('\t');
+    const text = rowData.map((cell) => formatValueForCopy(cell)).join('\t');
     navigator.clipboard.writeText(text);
-  }, [paginatedRows]);
+  }, [paginatedRows, formatValueForCopy]);
 
   // Keyboard navigation
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -315,12 +331,30 @@ export function ResultsTable({ results, filters, onFiltersChange, onExportCSV, o
     };
   }, []);
 
+  // Format a value for display as a string
+  const formatValue = (value: unknown): string => {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+    if (typeof value === 'object') {
+      // Handle BigQuery date wrapper objects and other objects
+      if ('value' in value && typeof (value as any).value !== 'undefined') {
+        return formatValue((value as any).value);
+      }
+      return JSON.stringify(value);
+    }
+    return String(value);
+  };
+
   // Format cell display
   const formatCell = (cell: unknown, isNull: boolean) => {
     if (isNull) {
       return showNullHighlight ? <span className="null-value">NULL</span> : '';
     }
-    return String(cell);
+    return formatValue(cell);
   };
 
   return (

--- a/src/renderer/components/ResultsTable.tsx
+++ b/src/renderer/components/ResultsTable.tsx
@@ -27,6 +27,14 @@ interface SelectedCell {
   col: number;
 }
 
+interface ContextMenuState {
+  visible: boolean;
+  x: number;
+  y: number;
+  row: number;
+  col: number;
+}
+
 // Determine if a value looks like a number
 function isNumericColumn(rows: unknown[][], columnIndex: number): boolean {
   let numericCount = 0;
@@ -101,6 +109,13 @@ export function ResultsTable({ results, filters, onFiltersChange, onExportCSV, o
   const [filterMenuAnchor, setFilterMenuAnchor] = useState<HTMLElement | null>(null);
   const [selectedCell, setSelectedCell] = useState<SelectedCell | null>(null);
   const [showNullHighlight, setShowNullHighlight] = useState(false);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState>({
+    visible: false,
+    x: 0,
+    y: 0,
+    row: 0,
+    col: 0,
+  });
 
   // Use filters from props
   const columnFilters = filters;
@@ -234,6 +249,32 @@ export function ResultsTable({ results, filters, onFiltersChange, onExportCSV, o
     navigator.clipboard.writeText(text);
   }, [paginatedRows, formatValueForCopy]);
 
+  // Handle right-click context menu
+  const handleContextMenu = useCallback((e: React.MouseEvent, row: number, col: number) => {
+    e.preventDefault();
+    setSelectedCell({ row, col });
+    setContextMenu({
+      visible: true,
+      x: e.clientX,
+      y: e.clientY,
+      row,
+      col,
+    });
+  }, []);
+
+  // Close context menu
+  const closeContextMenu = useCallback(() => {
+    setContextMenu(prev => ({ ...prev, visible: false }));
+  }, []);
+
+  // Close context menu when clicking outside
+  useEffect(() => {
+    if (!contextMenu.visible) return;
+    const handleClick = () => closeContextMenu();
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [contextMenu.visible, closeContextMenu]);
+
   // Keyboard navigation
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (!selectedCell) return;
@@ -266,7 +307,8 @@ export function ResultsTable({ results, filters, onFiltersChange, onExportCSV, o
       case 'c':
         if (e.metaKey || e.ctrlKey) {
           e.preventDefault();
-          copyRowValue(row);
+          // Copy just the selected cell, not the whole row
+          copyCellValue(row, col);
         }
         break;
       case 'Escape':
@@ -536,6 +578,7 @@ export function ResultsTable({ results, filters, onFiltersChange, onExportCSV, o
                           className={`table-cell ${isNull && showNullHighlight ? 'null-cell' : ''} ${isSelected ? 'selected' : ''}`}
                           style={{ width: `${width}px` }}
                           onClick={() => setSelectedCell({ row: virtualRow.index, col: cellIdx })}
+                          onContextMenu={(e) => handleContextMenu(e, virtualRow.index, cellIdx)}
                         >
                           {formatCell(cell, isNull)}
                         </div>
@@ -642,6 +685,49 @@ export function ResultsTable({ results, filters, onFiltersChange, onExportCSV, o
           </div>
         </div>
       </div>
+
+      {/* Context menu */}
+      {contextMenu.visible && (
+        <div
+          className="results-context-menu"
+          style={{
+            position: 'fixed',
+            left: contextMenu.x,
+            top: contextMenu.y,
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            className="context-menu-item"
+            onClick={() => {
+              copyCellValue(contextMenu.row, contextMenu.col);
+              closeContextMenu();
+            }}
+          >
+            Copy Cell
+          </button>
+          <button
+            className="context-menu-item"
+            onClick={() => {
+              copyRowValue(contextMenu.row);
+              closeContextMenu();
+            }}
+          >
+            Copy Row
+          </button>
+          {onCopyToClipboard && (
+            <button
+              className="context-menu-item"
+              onClick={() => {
+                onCopyToClipboard();
+                closeContextMenu();
+              }}
+            >
+              Copy All
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/utils/sqlCompletions.ts
+++ b/src/renderer/utils/sqlCompletions.ts
@@ -122,6 +122,52 @@ function createCompletionItem(
 }
 
 /**
+ * Check if the cursor position is inside a SQL comment.
+ * Handles both single-line (--) and multi-line block comments.
+ */
+export function isInComment(fullText: string, cursorOffset: number): boolean {
+  const textBeforeCursor = fullText.substring(0, cursorOffset);
+
+  // Check for single-line comment: -- to end of line
+  const lastNewline = textBeforeCursor.lastIndexOf('\n');
+  const currentLine = textBeforeCursor.substring(lastNewline + 1);
+
+  // Check if there's a -- on this line before the cursor (not inside a string)
+  let inString = false;
+  let stringChar = '';
+  for (let i = 0; i < currentLine.length; i++) {
+    const char = currentLine[i];
+    if (inString) {
+      if (char === stringChar && currentLine[i - 1] !== '\\') {
+        inString = false;
+      }
+    } else {
+      if (char === "'" || char === '"') {
+        inString = true;
+        stringChar = char;
+      } else if (char === '-' && currentLine[i + 1] === '-') {
+        return true; // Found -- outside of string
+      }
+    }
+  }
+
+  // Check for multi-line comment: count /* and */ pairs
+  let depth = 0;
+  for (let i = 0; i < textBeforeCursor.length - 1; i++) {
+    const twoChars = textBeforeCursor.substring(i, i + 2);
+    if (twoChars === '/*') {
+      depth++;
+      i++; // Skip next char
+    } else if (twoChars === '*/') {
+      depth = Math.max(0, depth - 1);
+      i++; // Skip next char
+    }
+  }
+
+  return depth > 0;
+}
+
+/**
  * Get completion items for SQL keywords
  */
 export function getKeywordCompletions(


### PR DESCRIPTION
## Summary

This PR addresses 7 GitHub issues with bug fixes and enhancements:

### Bug Fixes
- **#3**: Date fields now display correctly instead of `[object Object]`
- **#5**: MacOS keyboard shortcuts (Cmd+Enter, Cmd+Shift+Enter) now work properly
- **#7**: Renaming an open file updates the tab title instead of showing "deleted" warning
- **#10**: Saving a file no longer triggers "changed externally" banner

### Enhancements
- **#2**: Autocomplete no longer appears inside SQL comments
- **#4**: Users can now drag to resize the split between query editor and results
- **#12**: Cmd+C copies just the selected cell; right-click context menu added with Copy Cell/Row/All options

### Additional Fixes (found during testing)
- Fixed Cmd+Shift+Enter not executing all queries (stale closure issue)
- Fixed results status bar not showing when multiple queries are executed

## Test plan

- [x] Date fields display as ISO strings, not `[object Object]`
- [x] Cmd+Enter executes current query
- [x] Cmd+Shift+Enter executes all queries
- [x] Cmd+T opens new tab
- [x] Cmd+S saves file
- [x] Autocomplete does not appear in `-- comments` or `/* block comments */`
- [x] Saving a file does not show "changed externally" banner
- [x] Renaming an open file updates tab title
- [x] Dragging resize handle between editor/results works
- [x] Cmd+C copies selected cell value
- [x] Right-click context menu appears with Copy Cell/Row/All options
- [x] Results status bar visible with multiple query results

🤖 Generated with [Claude Code](https://claude.com/claude-code)